### PR TITLE
C4-723: Remove finishFailedMinipoolByMultisig

### DIFF
--- a/contracts/contract/MinipoolManager.sol
+++ b/contracts/contract/MinipoolManager.sol
@@ -523,15 +523,6 @@ contract MinipoolManager is Base, ReentrancyGuard, IWithdrawer {
 		_cancelMinipoolAndReturnFunds(nodeID, minipoolIndex);
 	}
 
-	/// @notice Multisig can move a minipool from the error state to the finished state, after a human review of the error
-	/// @param nodeID 20-byte Avalanche node ID
-	function finishFailedMinipoolByMultisig(address nodeID) external {
-		int256 minipoolIndex = onlyValidMultisig(nodeID);
-		requireValidStateTransition(minipoolIndex, MinipoolStatus.Finished);
-		setUint(keccak256(abi.encodePacked("minipool.item", minipoolIndex, ".status")), uint256(MinipoolStatus.Finished));
-		emit MinipoolStatusChanged(nodeID, MinipoolStatus.Finished);
-	}
-
 	//
 	// VIEW FUNCTIONS
 	//

--- a/test/unit/MinipoolManager.t.sol
+++ b/test/unit/MinipoolManager.t.sol
@@ -564,17 +564,16 @@ contract MinipoolManagerTest is BaseTest {
 		// The highwater doesnt get reset in this case
 		assertEq(staking.getAVAXAssignedHighWater(mp1Updated.owner), depositAmt);
 
-		// Test that multisig can move status to Finished after some kind of human review of error
+		// withdraw funds to move minipool to finished state
+		uint256 nodeOpStartingBalance = nodeOp.balance;
 
-		// will fail
-		vm.expectRevert(MinipoolManager.InvalidMultisigAddress.selector);
-		minipoolMgr.finishFailedMinipoolByMultisig(mp1Updated.nodeID);
+		vm.prank(nodeOp);
+		minipoolMgr.withdrawMinipoolFunds(mp1.nodeID);
 
-		vm.prank(address(rialto));
-		minipoolMgr.finishFailedMinipoolByMultisig(mp1Updated.nodeID);
-		MinipoolManager.Minipool memory mp1finished = minipoolMgr.getMinipool(minipoolIndex);
+		assertEq(nodeOp.balance, nodeOpStartingBalance + depositAmt);
 
-		assertEq(mp1finished.status, uint256(MinipoolStatus.Finished));
+		mp1Updated = minipoolMgr.getMinipool(minipoolIndex);
+		assertEq(mp1Updated.status, uint256(MinipoolStatus.Finished));
 	}
 
 	function testCancelMinipoolByMultisig() public {


### PR DESCRIPTION
C4 Issue: https://github.com/code-423n4/2022-12-gogopool-findings/issues/723

## What Changed
Remove the method `finishFailedMinipoolByMultisig` to ensure that a Node Operator is allowed to withdraw their funds. We're going to expect users to withdraw from the error state, and add an indication to the UI that the minipool failed and the Node Operator is able to withdraw. 

## Background
Previously we were going to have Rialto call `finishFailedMinipoolByMultisig` to transition a minipool from `Error` to `Finished`. However Node Operators are not able to withdraw their funds from `Finished`. 
