### PR TITLE
C4-742: Fix contract upgrades

### DIFF
--- a/contracts/contract/ProtocolDAO.sol
+++ b/contracts/contract/ProtocolDAO.sol
@@ -194,24 +194,27 @@ contract ProtocolDAO is Base {
 	}
 
 	/// @notice Unregister a contract with Storage
-	/// @param addr Contract address to unregister
-	function unregisterContract(address addr) public onlyGuardian {
-		string memory name = getContractName(addr);
-		deleteBool(keccak256(abi.encodePacked("contract.exists", addr)));
+	/// @param name Name of contract to unregister
+	function unregisterContract(string memory name) public onlyGuardian {
+		address addr = getContractAddress(name);
 		deleteAddress(keccak256(abi.encodePacked("contract.address", name)));
+
+		deleteBool(keccak256(abi.encodePacked("contract.exists", addr)));
 		deleteString(keccak256(abi.encodePacked("contract.name", addr)));
 	}
 
-	/// @notice Upgrade a contract by unregistering the existing address, and registring a new address and name
-	/// @param newAddr Address of the new contract
-	/// @param newName Name of the new contract
+	/// @notice Upgrade a contract by registring a new address and name, and unregistering the existing address
+	/// @param contractName Name of the new contract
 	/// @param existingAddr Address of the existing contract to be deleted
-	function upgradeExistingContract(
-		address newAddr,
-		string memory newName,
-		address existingAddr
+	/// @param newAddr Address of the new contract
+	function upgradeContract(
+		string memory contractName,
+		address existingAddr,
+		address newAddr
 	) external onlyGuardian {
-		registerContract(newAddr, newName);
-		unregisterContract(existingAddr);
+		registerContract(newAddr, contractName);
+
+		deleteBool(keccak256(abi.encodePacked("contract.exists", existingAddr)));
+		deleteString(keccak256(abi.encodePacked("contract.name", existingAddr)));
 	}
 }

--- a/contracts/contract/ProtocolDAO.sol
+++ b/contracts/contract/ProtocolDAO.sol
@@ -7,8 +7,10 @@ import {Storage} from "./Storage.sol";
 
 /// @title Settings for the Protocol
 contract ProtocolDAO is Base {
-	error ValueNotWithinRange();
 	error ContractAlreadyRegistered();
+	error ExistingContractNotRegistered();
+	error InvalidContract();
+	error ValueNotWithinRange();
 
 	modifier valueNotGreaterThanOne(uint256 setterValue) {
 		if (setterValue > 1 ether) {
@@ -193,6 +195,10 @@ contract ProtocolDAO is Base {
 			revert ContractAlreadyRegistered();
 		}
 
+		if (bytes(contractName).length == 0 || contractAddr == address(0)) {
+			revert InvalidContract();
+		}
+
 		setBool(keccak256(abi.encodePacked("contract.exists", contractAddr)), true);
 		setAddress(keccak256(abi.encodePacked("contract.address", contractName)), contractAddr);
 		setString(keccak256(abi.encodePacked("contract.name", contractAddr)), contractName);
@@ -216,6 +222,17 @@ contract ProtocolDAO is Base {
 		address existingAddr,
 		address newAddr
 	) external onlyGuardian {
+		if (
+			bytes(getString(keccak256(abi.encodePacked("contract.name", existingAddr)))).length == 0 ||
+			getAddress(keccak256(abi.encodePacked("contract.address", contractName))) == address(0)
+		) {
+			revert ExistingContractNotRegistered();
+		}
+
+		if (newAddr == address(0)) {
+			revert InvalidContract();
+		}
+
 		setAddress(keccak256(abi.encodePacked("contract.address", contractName)), newAddr);
 		setString(keccak256(abi.encodePacked("contract.name", newAddr)), contractName);
 		setBool(keccak256(abi.encodePacked("contract.exists", newAddr)), true);

--- a/contracts/contract/ProtocolDAO.sol
+++ b/contracts/contract/ProtocolDAO.sol
@@ -198,9 +198,8 @@ contract ProtocolDAO is Base {
 	function unregisterContract(string memory name) public onlyGuardian {
 		address addr = getContractAddress(name);
 		deleteAddress(keccak256(abi.encodePacked("contract.address", name)));
-
-		deleteBool(keccak256(abi.encodePacked("contract.exists", addr)));
 		deleteString(keccak256(abi.encodePacked("contract.name", addr)));
+		deleteBool(keccak256(abi.encodePacked("contract.exists", addr)));
 	}
 
 	/// @notice Upgrade a contract by registring a new address and name, and unregistering the existing address
@@ -214,7 +213,7 @@ contract ProtocolDAO is Base {
 	) external onlyGuardian {
 		registerContract(newAddr, contractName);
 
-		deleteBool(keccak256(abi.encodePacked("contract.exists", existingAddr)));
 		deleteString(keccak256(abi.encodePacked("contract.name", existingAddr)));
+		deleteBool(keccak256(abi.encodePacked("contract.exists", existingAddr)));
 	}
 }

--- a/test/unit/ProtocolDAO.t.sol
+++ b/test/unit/ProtocolDAO.t.sol
@@ -291,4 +291,27 @@ contract ProtocolDAOTest is BaseTest {
 		dao.upgradeContract(name, addr, existingAddr);
 		vm.stopPrank();
 	}
+
+	function testUpgradeProtocolDAO() public {
+		// set somethingn with the existing dao
+		vm.prank(guardian);
+		dao.setClaimingContractPct("TestContract", 0.2 ether);
+
+		ProtocolDAO newDao = new ProtocolDAO(store);
+
+		// upgrade dao
+		vm.prank(guardian);
+		dao.upgradeContract("ProtocolDAO", address(dao), address(newDao));
+
+		// verify new addresses
+		assertTrue(store.getBool(keccak256(abi.encodePacked("contract.exists", address(newDao)))));
+		assertEq(store.getAddress(keccak256(abi.encodePacked("contract.address", "ProtocolDAO"))), address(newDao));
+		assertEq(store.getString(keccak256(abi.encodePacked("contract.name", address(newDao)))), "ProtocolDAO");
+
+		// verify new dao works
+		assertEq(dao.getClaimingContractPct("TestContract"), 0.2 ether);
+
+		assertFalse(store.getBool(keccak256(abi.encodePacked("contract.exists", address(dao)))));
+		assertEq(store.getString(keccak256(abi.encodePacked("contract.name", address(dao)))), "");
+	}
 }

--- a/test/unit/ProtocolDAO.t.sol
+++ b/test/unit/ProtocolDAO.t.sol
@@ -187,7 +187,7 @@ contract ProtocolDAOTest is BaseTest {
 		vm.stopPrank();
 
 		vm.prank(guardian);
-		dao.registerContract(addr, name);
+		dao.registerContract(name, addr);
 
 		assertEq(store.getBool(keccak256(abi.encodePacked("contract.exists", addr))), true);
 		assertEq(store.getAddress(keccak256(abi.encodePacked("contract.address", name))), addr);
@@ -204,7 +204,21 @@ contract ProtocolDAOTest is BaseTest {
 
 		vm.startPrank(address(123));
 		vm.expectRevert(BaseAbstract.MustBeGuardian.selector);
-		dao.registerContract(addr, name);
+		dao.registerContract(name, addr);
+		vm.stopPrank();
+	}
+
+	function testRegisterContractAlreadyRegistered() public {
+		address addr = randAddress();
+		string memory name = "newContract";
+
+		vm.prank(guardian);
+		dao.registerContract(name, addr);
+
+		address newAddr = randAddress();
+		vm.startPrank(guardian);
+		vm.expectRevert(ProtocolDAO.ContractAlreadyRegistered.selector);
+		dao.registerContract(name, newAddr);
 		vm.stopPrank();
 	}
 
@@ -213,7 +227,7 @@ contract ProtocolDAOTest is BaseTest {
 		string memory name = "TestContract";
 
 		vm.prank(guardian);
-		dao.registerContract(addr, name);
+		dao.registerContract(name, addr);
 
 		assertEq(store.getBool(keccak256(abi.encodePacked("contract.exists", addr))), true);
 		assertEq(store.getAddress(keccak256(abi.encodePacked("contract.address", name))), addr);
@@ -252,7 +266,7 @@ contract ProtocolDAOTest is BaseTest {
 		address newAddr = randAddress();
 
 		vm.prank(guardian);
-		dao.registerContract(addr, name);
+		dao.registerContract(name, addr);
 		assertEq(store.getBool(keccak256(abi.encodePacked("contract.exists", addr))), true);
 		assertEq(store.getAddress(keccak256(abi.encodePacked("contract.address", name))), addr);
 		assertEq(store.getString(keccak256(abi.encodePacked("contract.name", addr))), name);

--- a/test/unit/ProtocolDAO.t.sol
+++ b/test/unit/ProtocolDAO.t.sol
@@ -178,7 +178,7 @@ contract ProtocolDAOTest is BaseTest {
 
 	function testRegisterContract() public {
 		address addr = randAddress();
-		string memory name = "newContract";
+		string memory name = "TestContract";
 		bytes32 testKey = "testKey";
 
 		vm.startPrank(addr);
@@ -210,8 +210,7 @@ contract ProtocolDAOTest is BaseTest {
 
 	function testUnregisterContract() public {
 		address addr = randAddress();
-		string memory name = "newContract";
-		bytes32 testKey = "testKey";
+		string memory name = "TestContract";
 
 		vm.prank(guardian);
 		dao.registerContract(addr, name);
@@ -220,12 +219,13 @@ contract ProtocolDAOTest is BaseTest {
 		assertEq(store.getAddress(keccak256(abi.encodePacked("contract.address", name))), addr);
 		assertEq(store.getString(keccak256(abi.encodePacked("contract.name", addr))), name);
 
+		bytes32 testKey = "testKey";
 		vm.prank(addr);
 		store.setBool(testKey, true);
 		assertEq(store.getBool(testKey), true);
 
 		vm.prank(guardian);
-		dao.unregisterContract(addr);
+		dao.unregisterContract(name);
 
 		assertEq(store.getBool(keccak256(abi.encodePacked("contract.exists", addr))), false);
 		assertEq(store.getAddress(keccak256(abi.encodePacked("contract.address", name))), address(0));
@@ -238,44 +238,44 @@ contract ProtocolDAOTest is BaseTest {
 	}
 
 	function testUnregisterContractNotGuardian() public {
-		address addr = randAddress();
+		string memory name = "TestContract";
 
 		vm.startPrank(address(123));
 		vm.expectRevert(BaseAbstract.MustBeGuardian.selector);
-		dao.unregisterContract(addr);
+		dao.unregisterContract(name);
 	}
 
 	function testUpgradeExistingContract() public {
 		address addr = randAddress();
-		string memory name = "newContract";
+		string memory name = "TestContract";
 
-		address existingAddr = randAddress();
-		string memory existingName = "existingName";
-
-		bytes32 testKey = "testKey";
+		address newAddr = randAddress();
 
 		vm.prank(guardian);
-		dao.registerContract(existingAddr, existingName);
-		assertEq(store.getBool(keccak256(abi.encodePacked("contract.exists", existingAddr))), true);
-		assertEq(store.getAddress(keccak256(abi.encodePacked("contract.address", existingName))), existingAddr);
-		assertEq(store.getString(keccak256(abi.encodePacked("contract.name", existingAddr))), existingName);
-
-		vm.prank(guardian);
-		dao.upgradeExistingContract(addr, name, existingAddr);
+		dao.registerContract(addr, name);
 		assertEq(store.getBool(keccak256(abi.encodePacked("contract.exists", addr))), true);
 		assertEq(store.getAddress(keccak256(abi.encodePacked("contract.address", name))), addr);
 		assertEq(store.getString(keccak256(abi.encodePacked("contract.name", addr))), name);
 
-		assertEq(store.getBool(keccak256(abi.encodePacked("contract.exists", existingAddr))), false);
-		assertEq(store.getAddress(keccak256(abi.encodePacked("contract.address", existingName))), address(0));
-		assertEq(store.getString(keccak256(abi.encodePacked("contract.name", existingAddr))), "");
+		vm.prank(guardian);
+		dao.upgradeContract(name, addr, newAddr);
+		// verify new address is set
+		assertTrue(store.getBool(keccak256(abi.encodePacked("contract.exists", newAddr))));
+		assertEq(store.getAddress(keccak256(abi.encodePacked("contract.address", name))), newAddr);
+		assertEq(store.getString(keccak256(abi.encodePacked("contract.name", newAddr))), name);
 
-		vm.startPrank(existingAddr);
+		// verify old address is deleted
+		assertFalse(store.getBool(keccak256(abi.encodePacked("contract.exists", addr))));
+		assertEq(store.getString(keccak256(abi.encodePacked("contract.name", addr))), "");
+
+		bytes32 testKey = "testKey";
+
+		vm.startPrank(addr);
 		vm.expectRevert(BaseAbstract.InvalidOrOutdatedContract.selector);
 		store.setBool(testKey, true);
 		vm.stopPrank();
 
-		vm.prank(addr);
+		vm.prank(newAddr);
 		store.setBool(testKey, true);
 		assertEq(store.getBool(testKey), true);
 	}
@@ -283,11 +283,12 @@ contract ProtocolDAOTest is BaseTest {
 	function testUpgradeExistingContractNotGuardian() public {
 		address addr = randAddress();
 		string memory name = "newContract";
+
 		address existingAddr = randAddress();
 
 		vm.startPrank(address(123));
 		vm.expectRevert(BaseAbstract.MustBeGuardian.selector);
-		dao.upgradeExistingContract(addr, name, existingAddr);
+		dao.upgradeContract(name, addr, existingAddr);
 		vm.stopPrank();
 	}
 }


### PR DESCRIPTION
C4 Issues: 
https://github.com/code-423n4/2022-12-gogopool-findings/issues/742
https://github.com/code-423n4/2022-12-gogopool-findings/issues/729

## What changed
The Upgrade method now doesn't delete the address associated with the contract name just after setting it, allowing contracts to be upgraded with the same name. We also now delete the boolean value of contract exists last, so that the ProtocolDAO itself can be upgraded.

Added some additional sanity checks when upgrading and registering.
