### PR TITLE
C4-533 ggAVAX: ensure amountAvailableForStaking doesn't underflow

### DIFF
--- a/contracts/contract/tokens/TokenggAVAX.sol
+++ b/contracts/contract/tokens/TokenggAVAX.sol
@@ -138,6 +138,10 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, UUPSUpgradeable, Base
 		uint256 totalAssets_ = totalAssets();
 
 		uint256 reservedAssets = totalAssets_.mulDivDown(targetCollateralRate, 1 ether);
+
+		if (reservedAssets + stakingTotalAssets > totalAssets_) {
+			return 0;
+		}
 		return totalAssets_ - reservedAssets - stakingTotalAssets;
 	}
 


### PR DESCRIPTION
C4 Issue: https://github.com/code-423n4/2022-12-gogopool-findings/issues/533

The function amountAvailableForStaking can underflow when total assets decreases and the amount out for staking eats into the reserve amount. This is a fine situation in our contracts and will correct itself as AVAX used for validating is deposited, then the amount in reserve will grow.

However in the mean time, we should not let amountAvailableForStaking to underflow.