### PR TITLE
C4-476: ggAVAX max redeem incorrect, not fixing

### DIFF
--- a/test/unit/TokenggAVAX.t.sol
+++ b/test/unit/TokenggAVAX.t.sol
@@ -447,6 +447,115 @@ contract TokenggAVAXTest is BaseTest, IWithdrawer {
 		assertEq(assets, 0);
 	}
 
+	function testMaxRedeem() public {
+		uint128 depositAmt = 1000 ether;
+		uint128 rewardAmt = 100 ether;
+
+		address liqStaker = getActorWithTokens("liqStaker", depositAmt, 0 ether);
+		address rewarder = getActorWithTokens("rewarder", rewardAmt, 0 ether);
+
+		// deposit
+		vm.prank(liqStaker);
+		ggAVAX.depositAVAX{value: depositAmt}();
+
+		assertEq(ggAVAX.maxRedeem(liqStaker), depositAmt);
+
+		// transfer rewards without syncing
+		vm.prank(rewarder);
+		wavax.transfer(address(ggAVAX), rewardAmt);
+
+		assertEq(ggAVAX.maxRedeem(liqStaker), depositAmt);
+
+		// sync rewards
+		vm.warp(ggAVAX.rewardsCycleEnd());
+		ggAVAX.syncRewards();
+
+		// skip halfway through rewards cycle
+		skip(ggAVAX.rewardsCycleLength() / 2);
+
+		assertEq(ggAVAX.maxRedeem(liqStaker), depositAmt);
+	}
+
+	function testMaxWithdraw() public {
+		uint128 depositAmt = 1000 ether;
+		uint128 rewardAmt = 100 ether;
+
+		address liqStaker = getActorWithTokens("liqStaker", depositAmt, 0 ether);
+		address rewarder = getActorWithTokens("rewarder", rewardAmt, 0 ether);
+
+		// deposit
+		vm.prank(liqStaker);
+		ggAVAX.depositAVAX{value: depositAmt}();
+
+		assertEq(ggAVAX.maxWithdraw(liqStaker), depositAmt);
+
+		// transfer rewards without syncing
+		vm.prank(rewarder);
+		wavax.transfer(address(ggAVAX), rewardAmt);
+
+		assertEq(ggAVAX.maxWithdraw(liqStaker), depositAmt);
+
+		// sync rewards
+		vm.warp(ggAVAX.rewardsCycleEnd());
+		ggAVAX.syncRewards();
+
+		// skip halfway through rewards cycle
+		skip(ggAVAX.rewardsCycleLength() / 2);
+
+		assertEq(ggAVAX.maxWithdraw(liqStaker), depositAmt + (rewardAmt / 2));
+	}
+
+	/// @dev Test redeem shares mid rewards cycle
+	///      There is an issue that causes redeem or withdraw to revert
+	///      when a liquid staker is able to withdraw all contract assets
+	///      mid rewards cycle. This is unlikely to happen in production
+	///      when the protocol has a larger number of stakers
+	function testFailRedeemWithdrawAllAssetsMidRewardsCycle() public {
+		uint128 seed = 1000;
+		uint128 reward = 100;
+
+		// start at fresh rewards cycle
+		vm.warp(ggAVAX.rewardsCycleEnd());
+
+		address liqStaker = getActorWithTokens("liqStaker", seed, 0 ether);
+
+		vm.prank(liqStaker);
+
+		// first seed pool
+		ggAVAX.depositAVAX{value: seed}();
+		assertEq(ggAVAX.totalAssets(), seed);
+
+		// mint rewards to pool
+		vm.prank(liqStaker);
+		wavax.transfer(address(ggAVAX), reward);
+		assertEq(ggAVAX.lastRewardsAmt(), 0);
+		assertEq(ggAVAX.totalAssets(), seed);
+		assertEq(ggAVAX.convertToAssets(seed), seed); // 1:1 still
+
+		// sync rewards
+		ggAVAX.syncRewards();
+		assertEq(ggAVAX.lastRewardsAmt(), reward);
+		assertEq(ggAVAX.totalAssets(), seed);
+		assertEq(ggAVAX.convertToAssets(seed), seed); // 1:1 still
+
+		// skip half a rewards cycle
+		skip(ggAVAX.rewardsCycleLength() / 2);
+		assertEq(ggAVAX.lastRewardsAmt(), reward);
+		assertEq(ggAVAX.totalAssets(), uint256(seed) + (reward / 2));
+		assertEq(ggAVAX.convertToAssets(seed), uint256(seed) + (reward / 2)); // half rewards added
+		assertEq(ggAVAX.convertToShares(uint256(seed) + (reward / 2)), seed); // half rewards added
+
+		assertEq(ggAVAX.balanceOf(liqStaker), seed);
+
+		// attempt to redeem all shares, which fails
+		vm.prank(liqStaker);
+		ggAVAX.redeem(ggAVAX.maxRedeem(liqStaker), liqStaker, liqStaker);
+
+		// attempt to withdraw all assets, which fails
+		vm.prank(liqStaker);
+		ggAVAX.withdraw(ggAVAX.maxWithdraw(liqStaker), liqStaker, liqStaker);
+	}
+
 	function testMaxRedeemPaused() public {
 		vm.prank(address(ocyticus));
 		dao.pauseContract("TokenggAVAX");


### PR DESCRIPTION
C4-issue: https://github.com/code-423n4/2022-12-gogopool-findings/issues/476

The issue comes from trying to redeem assets that aren't yet included in totalReleasedAssets. i.e. in the middle of a rewards cycle. If there is not enough liquidity in the contract, the beforeWithdraw method can underflow when subtracting the amount to redeem.

We're aware of this issue and do not plan on fixing. I've added a test that demonstrates the error case.

The issue is unlikely in production when there are more stakers and more value in the contract and the contract isn't withdrawn to 0 by one staker.