### PR TITLE
C4-446: Remove UUPS from TokenggAVAX

### DIFF
--- a/contracts/contract/tokens/TokenggAVAX.sol
+++ b/contracts/contract/tokens/TokenggAVAX.sol
@@ -13,7 +13,6 @@ import {IWithdrawer} from "../../interface/IWithdrawer.sol";
 import {IWAVAX} from "../../interface/IWAVAX.sol";
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 import {ERC20} from "@rari-capital/solmate/src/mixins/ERC4626.sol";
 import {FixedPointMathLib} from "@rari-capital/solmate/src/utils/FixedPointMathLib.sol";
@@ -21,7 +20,7 @@ import {SafeCastLib} from "@rari-capital/solmate/src/utils/SafeCastLib.sol";
 import {SafeTransferLib} from "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
 
 /// @dev Local variables and parent contracts must remain in order between contract upgrades
-contract TokenggAVAX is Initializable, ERC4626Upgradeable, UUPSUpgradeable, BaseUpgradeable {
+contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	using SafeTransferLib for ERC20;
 	using SafeTransferLib for address;
 	using SafeCastLib for *;
@@ -297,9 +296,6 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, UUPSUpgradeable, Base
 	) internal override {
 		totalReleasedAssets += amount;
 	}
-
-	/// @notice Will revert if msg.sender is not authorized to upgrade the contract
-	function _authorizeUpgrade(address newImplementation) internal override onlyGuardian {}
 
 	/// @notice Override of ERC20Upgradeable to set the contract version for EIP-2612
 	/// @return hash of this contracts version

--- a/test/unit/TokenUpgradeTests.t.sol
+++ b/test/unit/TokenUpgradeTests.t.sol
@@ -7,29 +7,87 @@ import "./utils/BaseTest.sol";
 import {MockTokenggAVAXV2} from "./utils/MockTokenggAVAXV2.sol";
 import {MockTokenggAVAXV2Dangerous} from "./utils/MockTokenggAVAXV2Dangerous.sol";
 import {MockTokenggAVAXV2Safe} from "./utils/MockTokenggAVAXV2Safe.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 contract TokenUpgradeTests is BaseTest {
+	address public constant DEPLOYER = address(12345);
+
 	function setUp() public override {
 		super.setUp();
 	}
 
+	function testDeployTransparentProxy() public {
+		// deploy token contract
+		vm.startPrank(DEPLOYER);
+
+		ProxyAdmin proxyAdmin = new ProxyAdmin();
+		TokenggAVAX ggAVAXImpl = new TokenggAVAX();
+
+		TransparentUpgradeableProxy ggAVAXProxy = new TransparentUpgradeableProxy(
+			address(ggAVAXImpl),
+			address(proxyAdmin),
+			abi.encodeWithSelector(ggAVAXImpl.initialize.selector, store, wavax, 0)
+		);
+		TokenggAVAX token = TokenggAVAX(payable(address(ggAVAXProxy)));
+
+		assertEq(proxyAdmin.getProxyImplementation(ggAVAXProxy), address(ggAVAXImpl));
+		proxyAdmin.transferOwnership(guardian);
+		vm.stopPrank();
+
+		// verify token works
+		address alice = getActorWithTokens("alice", 100 ether, 0);
+		vm.deal(alice, MAX_AMT);
+		vm.startPrank(alice);
+		uint256 shareAmount = token.depositAVAX{value: 100 ether}();
+		assertEq(shareAmount, 100 ether);
+		assertEq(token.totalAssets(), 100 ether);
+		assertEq(token.balanceOf(alice), 100 ether);
+		vm.stopPrank();
+		assertEq(proxyAdmin.owner(), guardian);
+
+		// upgrade contract
+		vm.prank(DEPLOYER);
+		MockTokenggAVAXV2 ggAVAXImplV2 = new MockTokenggAVAXV2();
+
+		vm.prank(guardian);
+		proxyAdmin.upgrade(ggAVAXProxy, address(ggAVAXImplV2));
+
+		// Verify data is still there
+		assertEq(shareAmount, 100 ether);
+		assertEq(token.totalAssets(), 100 ether);
+		assertEq(token.balanceOf(alice), 100 ether);
+
+		assertEq(proxyAdmin.getProxyImplementation(ggAVAXProxy), address(ggAVAXImplV2));
+	}
+
 	function testDomainSeparatorBetweenVersions() public {
 		// initialize token
+		vm.startPrank(DEPLOYER);
+		ProxyAdmin proxyAdmin = new ProxyAdmin();
 		TokenggAVAX impl = new TokenggAVAX();
-		TokenggAVAX proxy = TokenggAVAX(deployProxy(address(impl), guardian));
 
-		proxy.initialize(store, wavax, 0);
+		TransparentUpgradeableProxy transparentProxy = new TransparentUpgradeableProxy(
+			address(impl),
+			address(proxyAdmin),
+			abi.encodeWithSelector(impl.initialize.selector, store, wavax, 0)
+		);
+
+		TokenggAVAX proxy = TokenggAVAX(payable(address(transparentProxy)));
+
+		proxyAdmin.transferOwnership(guardian);
+		vm.stopPrank();
 
 		bytes32 oldSeparator = proxy.DOMAIN_SEPARATOR();
 		address oldAddress = address(proxy);
 		string memory oldName = proxy.name();
+		console.log("fail here?");
 
 		// upgrade implementation
+		vm.prank(DEPLOYER);
 		MockTokenggAVAXV2 impl2 = new MockTokenggAVAXV2();
-		vm.prank(guardian);
-		proxy.upgradeTo(address(impl2));
 
-		proxy.initialize(store, wavax, 0);
+		vm.prank(guardian);
+		proxyAdmin.upgradeAndCall(transparentProxy, address(impl2), abi.encodeWithSelector(impl2.initialize.selector, store, wavax, 0));
 
 		assertFalse(proxy.DOMAIN_SEPARATOR() == oldSeparator);
 		assertEq(address(proxy), oldAddress);
@@ -38,13 +96,20 @@ contract TokenUpgradeTests is BaseTest {
 
 	function testStorageGapDangerouslySet() public {
 		// initialize token
+		vm.startPrank(DEPLOYER);
+		ProxyAdmin proxyAdmin = new ProxyAdmin();
 		TokenggAVAX impl = new TokenggAVAX();
-		TokenggAVAX proxy = TokenggAVAX(deployProxy(address(impl), guardian));
 
-		proxy.initialize(store, wavax, 0);
+		TransparentUpgradeableProxy transparentProxy = new TransparentUpgradeableProxy(
+			address(impl),
+			address(proxyAdmin),
+			abi.encodeWithSelector(impl.initialize.selector, store, wavax, 0)
+		);
 
-		proxy.syncRewards();
-		vm.warp(ggAVAX.rewardsCycleEnd());
+		TokenggAVAX proxy = TokenggAVAX(payable(address(transparentProxy)));
+
+		proxyAdmin.transferOwnership(guardian);
+		vm.stopPrank();
 
 		// add some rewards to make sure error error occurs
 		address alice = getActorWithTokens("alice", 1000 ether, 0 ether);
@@ -56,10 +121,11 @@ contract TokenUpgradeTests is BaseTest {
 		bytes32 oldDomainSeparator = proxy.DOMAIN_SEPARATOR();
 
 		// upgrade implementation
+		vm.prank(DEPLOYER);
 		MockTokenggAVAXV2Dangerous impl2 = new MockTokenggAVAXV2Dangerous();
+
 		vm.prank(guardian);
-		proxy.upgradeTo(address(impl2));
-		proxy.initialize(store, wavax, 0);
+		proxyAdmin.upgradeAndCall(transparentProxy, address(impl2), abi.encodeWithSelector(impl2.initialize.selector, store, wavax, 0));
 
 		// now lastSync is reading four bytes of lastRewardsAmt
 		assertFalse(proxy.lastSync() == oldLastSync);
@@ -70,20 +136,30 @@ contract TokenUpgradeTests is BaseTest {
 
 	function testStorageGapSafe() public {
 		// initialize token
+		vm.startPrank(DEPLOYER);
+		ProxyAdmin proxyAdmin = new ProxyAdmin();
 		TokenggAVAX impl = new TokenggAVAX();
-		TokenggAVAX proxy = TokenggAVAX(deployProxy(address(impl), guardian));
 
-		proxy.initialize(store, wavax, 0);
+		TransparentUpgradeableProxy transparentProxy = new TransparentUpgradeableProxy(
+			address(impl),
+			address(proxyAdmin),
+			abi.encodeWithSelector(impl.initialize.selector, store, wavax, 0)
+		);
+
+		TokenggAVAX proxy = TokenggAVAX(payable(address(transparentProxy)));
+
+		proxyAdmin.transferOwnership(guardian);
+		vm.stopPrank();
 
 		proxy.syncRewards();
 		uint256 oldLastSync = proxy.lastSync();
 		bytes32 oldDomainSeparator = proxy.DOMAIN_SEPARATOR();
 
 		// upgrade implementation
+		vm.prank(DEPLOYER);
 		MockTokenggAVAXV2Safe impl2 = new MockTokenggAVAXV2Safe();
 		vm.prank(guardian);
-		proxy.upgradeTo(address(impl2));
-		proxy.initialize(store, wavax, 0);
+		proxyAdmin.upgradeAndCall(transparentProxy, address(impl2), abi.encodeWithSelector(impl2.initialize.selector, store, wavax, 0));
 
 		// verify that lastSync is not overwritten during upgrade
 		assertEq(proxy.lastSync(), oldLastSync);

--- a/test/unit/utils/BaseTest.sol
+++ b/test/unit/utils/BaseTest.sol
@@ -27,6 +27,7 @@ import {format} from "sol-utils/format.sol";
 import {ERC20} from "@rari-capital/solmate/src/tokens/ERC20.sol";
 import {FixedPointMathLib} from "@rari-capital/solmate/src/utils/FixedPointMathLib.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 abstract contract BaseTest is Test {
@@ -50,6 +51,7 @@ abstract contract BaseTest is Test {
 	TokenGGP public ggp;
 	TokenggAVAX public ggAVAX;
 	TokenggAVAX public ggAVAXImpl;
+	ProxyAdmin public proxyAdmin;
 	WAVAX public wavax;
 	MinipoolManager public minipoolMgr;
 	MultisigManager public multisigMgr;
@@ -93,12 +95,17 @@ abstract contract BaseTest is Test {
 		wavax = new WAVAX();
 
 		ggAVAXImpl = new TokenggAVAX();
-		ggAVAX = TokenggAVAX(deployProxy(address(ggAVAXImpl), guardian));
+		proxyAdmin = new ProxyAdmin();
+		// prettier-ignore
+		ggAVAX = TokenggAVAX(
+			deployProxyWithAdmin(
+				address(ggAVAXImpl),
+			 	abi.encodeWithSelector(ggAVAXImpl.initialize.selector, store, wavax, 0),
+				proxyAdmin,
+				guardian
+			)
+		);
 		registerContract(store, "TokenggAVAX", address(ggAVAX));
-
-		vm.stopPrank();
-		ggAVAX.initialize(store, wavax, 0 ether);
-		vm.startPrank(guardian);
 
 		minipoolMgr = new MinipoolManager(store);
 		registerContract(store, "MinipoolManager", address(minipoolMgr));
@@ -344,5 +351,16 @@ abstract contract BaseTest is Test {
 		bytes memory data;
 		TransparentUpgradeableProxy uups = new TransparentUpgradeableProxy(address(impl), deployer, data);
 		return payable(uups);
+	}
+
+	function deployProxyWithAdmin(
+		address impl,
+		bytes memory toCall,
+		ProxyAdmin admin,
+		address owner
+	) internal returns (address payable) {
+		TransparentUpgradeableProxy transparentProxy = new TransparentUpgradeableProxy(address(impl), address(proxyAdmin), toCall);
+		admin.transferOwnership(owner);
+		return payable(transparentProxy);
 	}
 }

--- a/test/unit/utils/MockTokenggAVAXV2.sol
+++ b/test/unit/utils/MockTokenggAVAXV2.sol
@@ -13,7 +13,6 @@ import {IWithdrawer} from "../../../contracts/interface/IWithdrawer.sol";
 import {IWAVAX} from "../../../contracts/interface/IWAVAX.sol";
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 import {ERC20} from "@rari-capital/solmate/src/mixins/ERC4626.sol";
 import {FixedPointMathLib} from "@rari-capital/solmate/src/utils/FixedPointMathLib.sol";
@@ -21,7 +20,7 @@ import {SafeCastLib} from "@rari-capital/solmate/src/utils/SafeCastLib.sol";
 import {SafeTransferLib} from "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
 
 /// @dev Local variables and parent contracts must remain in order between contract upgrades
-contract MockTokenggAVAXV2 is Initializable, ERC4626Upgradeable, UUPSUpgradeable, BaseUpgradeable {
+contract MockTokenggAVAXV2 is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	using SafeTransferLib for ERC20;
 	using SafeTransferLib for address;
 	using SafeCastLib for *;
@@ -275,9 +274,6 @@ contract MockTokenggAVAXV2 is Initializable, ERC4626Upgradeable, UUPSUpgradeable
 	) internal override {
 		totalReleasedAssets += amount;
 	}
-
-	/// @notice Will revert if msg.sender is not authorized to upgrade the contract
-	function _authorizeUpgrade(address newImplementation) internal override onlyGuardian {}
 
 	function versionHash() internal view override returns (bytes32) {
 		return keccak256(abi.encodePacked(version));

--- a/test/unit/utils/MockTokenggAVAXV2Dangerous.sol
+++ b/test/unit/utils/MockTokenggAVAXV2Dangerous.sol
@@ -14,7 +14,6 @@ import {IWithdrawer} from "../../../contracts/interface/IWithdrawer.sol";
 import {IWAVAX} from "../../../contracts/interface/IWAVAX.sol";
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 import {ERC20} from "@rari-capital/solmate/src/mixins/ERC4626.sol";
 import {FixedPointMathLib} from "@rari-capital/solmate/src/utils/FixedPointMathLib.sol";
@@ -23,7 +22,7 @@ import {SafeTransferLib} from "@rari-capital/solmate/src/utils/SafeTransferLib.s
 import {console} from "forge-std/console.sol";
 
 /// @dev Local variables and parent contracts must remain in order between contract upgrades
-contract MockTokenggAVAXV2Dangerous is Initializable, ERC4626UpgradeableDangerous, UUPSUpgradeable, BaseUpgradeable {
+contract MockTokenggAVAXV2Dangerous is Initializable, ERC4626UpgradeableDangerous, BaseUpgradeable {
 	using SafeTransferLib for ERC20;
 	using SafeTransferLib for address;
 	using SafeCastLib for *;
@@ -277,9 +276,6 @@ contract MockTokenggAVAXV2Dangerous is Initializable, ERC4626UpgradeableDangerou
 	) internal override {
 		totalReleasedAssets += amount;
 	}
-
-	/// @notice Will revert if msg.sender is not authorized to upgrade the contract
-	function _authorizeUpgrade(address newImplementation) internal override onlyGuardian {}
 
 	function versionHash() internal view override returns (bytes32) {
 		return keccak256(abi.encodePacked(version));

--- a/test/unit/utils/MockTokenggAVAXV2Safe.sol
+++ b/test/unit/utils/MockTokenggAVAXV2Safe.sol
@@ -12,7 +12,6 @@ import {IWithdrawer} from "../../../contracts/interface/IWithdrawer.sol";
 import {IWAVAX} from "../../../contracts/interface/IWAVAX.sol";
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 import {ERC20} from "@rari-capital/solmate/src/mixins/ERC4626.sol";
 import {FixedPointMathLib} from "@rari-capital/solmate/src/utils/FixedPointMathLib.sol";
@@ -21,7 +20,7 @@ import {SafeTransferLib} from "@rari-capital/solmate/src/utils/SafeTransferLib.s
 import {console} from "forge-std/console.sol";
 
 /// @dev Local variables and parent contracts must remain in order between contract upgrades
-contract MockTokenggAVAXV2Safe is Initializable, ERC4626UpgradeableSafe, UUPSUpgradeable, BaseUpgradeable {
+contract MockTokenggAVAXV2Safe is Initializable, ERC4626UpgradeableSafe, BaseUpgradeable {
 	using SafeTransferLib for ERC20;
 	using SafeTransferLib for address;
 	using SafeCastLib for *;
@@ -275,9 +274,6 @@ contract MockTokenggAVAXV2Safe is Initializable, ERC4626UpgradeableSafe, UUPSUpg
 	) internal override {
 		totalReleasedAssets += amount;
 	}
-
-	/// @notice Will revert if msg.sender is not authorized to upgrade the contract
-	function _authorizeUpgrade(address newImplementation) internal override onlyGuardian {}
 
 	function versionHash() internal view override returns (bytes32) {
 		return keccak256(abi.encodePacked(version));


### PR DESCRIPTION
C4 Issue: https://github.com/code-423n4/2022-12-gogopool-findings/issues/446

This issue drew our attention to how we were deploying the ggAVAX proxy, and we settled on using a Transparent Proxy pattern rather than the UUPS Upgradeable pattern. So we removed UUPS entirely. 