### PR TITLE
C4-739: Standardize ggp usage

### DIFF
--- a/contracts/contract/ClaimNodeOp.sol
+++ b/contracts/contract/ClaimNodeOp.sol
@@ -10,7 +10,6 @@ import {Storage} from "./Storage.sol";
 import {TokenGGP} from "./tokens/TokenGGP.sol";
 import {Vault} from "./Vault.sol";
 
-import {ERC20} from "@rari-capital/solmate/src/tokens/ERC20.sol";
 import {FixedPointMathLib} from "@rari-capital/solmate/src/utils/FixedPointMathLib.sol";
 
 /// @title Node Operators claiming GGP Rewards
@@ -24,11 +23,8 @@ contract ClaimNodeOp is Base {
 
 	event GGPRewardsClaimed(address indexed to, uint256 amount);
 
-	ERC20 public immutable ggp;
-
-	constructor(Storage storageAddress, ERC20 ggp_) Base(storageAddress) {
+	constructor(Storage storageAddress) Base(storageAddress) {
 		version = 1;
-		ggp = ggp_;
 	}
 
 	/// @notice Get the total rewards for the most recent cycle
@@ -99,6 +95,7 @@ contract ClaimNodeOp is Base {
 		staking.decreaseGGPRewards(msg.sender, ggpRewards);
 
 		Vault vault = Vault(getContractAddress("Vault"));
+		TokenGGP ggp = TokenGGP(getContractAddress("TokenGGP"));
 		uint256 restakeAmt = ggpRewards - claimAmt;
 		if (restakeAmt > 0) {
 			vault.withdrawToken(address(this), ggp, restakeAmt);

--- a/contracts/contract/MinipoolManager.sol
+++ b/contracts/contract/MinipoolManager.sol
@@ -10,10 +10,7 @@ import {ProtocolDAO} from "./ProtocolDAO.sol";
 import {Staking} from "./Staking.sol";
 import {Storage} from "./Storage.sol";
 import {TokenggAVAX} from "./tokens/TokenggAVAX.sol";
-import {TokenGGP} from "./tokens/TokenGGP.sol";
 import {Vault} from "./Vault.sol";
-
-import {ERC20} from "@rari-capital/solmate/src/mixins/ERC4626.sol";
 import {FixedPointMathLib} from "@rari-capital/solmate/src/utils/FixedPointMathLib.sol";
 import {ReentrancyGuard} from "@rari-capital/solmate/src/utils/ReentrancyGuard.sol";
 import {SafeTransferLib} from "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
@@ -58,7 +55,6 @@ import {SafeTransferLib} from "@rari-capital/solmate/src/utils/SafeTransferLib.s
 contract MinipoolManager is Base, ReentrancyGuard, IWithdrawer {
 	using FixedPointMathLib for uint256;
 	using SafeTransferLib for address;
-	using SafeTransferLib for ERC20;
 
 	error CancellationTooEarly();
 	error DurationOutOfBounds();
@@ -79,9 +75,6 @@ contract MinipoolManager is Base, ReentrancyGuard, IWithdrawer {
 
 	event GGPSlashed(address indexed nodeID, uint256 ggp);
 	event MinipoolStatusChanged(address indexed nodeID, MinipoolStatus indexed status);
-
-	ERC20 public immutable ggp;
-	TokenggAVAX public immutable ggAVAX;
 
 	/// @dev Not used for storage, just for returning data from view functions
 	struct Minipool {
@@ -180,14 +173,8 @@ contract MinipoolManager is Base, ReentrancyGuard, IWithdrawer {
 		}
 	}
 
-	constructor(
-		Storage storageAddress,
-		ERC20 ggp_,
-		TokenggAVAX ggAVAX_
-	) Base(storageAddress) {
+	constructor(Storage storageAddress) Base(storageAddress) {
 		version = 1;
-		ggp = ggp_;
-		ggAVAX = ggAVAX_;
 	}
 
 	//
@@ -328,6 +315,7 @@ contract MinipoolManager is Base, ReentrancyGuard, IWithdrawer {
 		int256 minipoolIndex = onlyValidMultisig(nodeID);
 		requireValidStateTransition(minipoolIndex, MinipoolStatus.Launched);
 
+		TokenggAVAX ggAVAX = TokenggAVAX(payable(getContractAddress("TokenggAVAX")));
 		uint256 avaxLiquidStakerAmt = getUint(keccak256(abi.encodePacked("minipool.item", minipoolIndex, ".avaxLiquidStakerAmt")));
 		return avaxLiquidStakerAmt <= ggAVAX.amountAvailableForStaking();
 	}
@@ -343,6 +331,7 @@ contract MinipoolManager is Base, ReentrancyGuard, IWithdrawer {
 		uint256 avaxLiquidStakerAmt = getUint(keccak256(abi.encodePacked("minipool.item", minipoolIndex, ".avaxLiquidStakerAmt")));
 
 		// Transfer funds to this contract and then send to multisig
+		TokenggAVAX ggAVAX = TokenggAVAX(payable(getContractAddress("TokenggAVAX")));
 		ggAVAX.withdrawForStaking(avaxLiquidStakerAmt);
 		addUint(keccak256("MinipoolManager.TotalAVAXLiquidStakerAmt"), avaxLiquidStakerAmt);
 
@@ -408,14 +397,12 @@ contract MinipoolManager is Base, ReentrancyGuard, IWithdrawer {
 		int256 minipoolIndex = onlyValidMultisig(nodeID);
 		requireValidStateTransition(minipoolIndex, MinipoolStatus.Withdrawable);
 
-		uint256 startTime = getUint(keccak256(abi.encodePacked("minipool.item", minipoolIndex, ".startTime")));
-		if (endTime <= startTime || endTime > block.timestamp) {
+		Minipool memory mp = getMinipool(minipoolIndex);
+		if (endTime <= mp.startTime || endTime > block.timestamp) {
 			revert InvalidEndTime();
 		}
 
-		uint256 avaxNodeOpAmt = getUint(keccak256(abi.encodePacked("minipool.item", minipoolIndex, ".avaxNodeOpAmt")));
-		uint256 avaxLiquidStakerAmt = getUint(keccak256(abi.encodePacked("minipool.item", minipoolIndex, ".avaxLiquidStakerAmt")));
-		uint256 totalAvaxAmt = avaxNodeOpAmt + avaxLiquidStakerAmt;
+		uint256 totalAvaxAmt = mp.avaxNodeOpAmt + mp.avaxLiquidStakerAmt;
 		if (msg.value != totalAvaxAmt + avaxTotalRewardAmt) {
 			revert InvalidAmount();
 		}
@@ -443,16 +430,15 @@ contract MinipoolManager is Base, ReentrancyGuard, IWithdrawer {
 
 		// Send the nodeOps AVAX + rewards to vault so they can claim later
 		Vault vault = Vault(getContractAddress("Vault"));
-		vault.depositAVAX{value: avaxNodeOpAmt + avaxNodeOpRewardAmt}();
+		vault.depositAVAX{value: mp.avaxNodeOpAmt + avaxNodeOpRewardAmt}();
 		// Return Liq stakers funds + rewards
-		ggAVAX.depositFromStaking{value: avaxLiquidStakerAmt + avaxLiquidStakerRewardAmt}(avaxLiquidStakerAmt, avaxLiquidStakerRewardAmt);
-		subUint(keccak256("MinipoolManager.TotalAVAXLiquidStakerAmt"), avaxLiquidStakerAmt);
-
-		address owner = getAddress(keccak256(abi.encodePacked("minipool.item", minipoolIndex, ".owner")));
+		TokenggAVAX ggAVAX = TokenggAVAX(payable(getContractAddress("TokenggAVAX")));
+		ggAVAX.depositFromStaking{value: mp.avaxLiquidStakerAmt + avaxLiquidStakerRewardAmt}(mp.avaxLiquidStakerAmt, avaxLiquidStakerRewardAmt);
+		subUint(keccak256("MinipoolManager.TotalAVAXLiquidStakerAmt"), mp.avaxLiquidStakerAmt);
 
 		Staking staking = Staking(getContractAddress("Staking"));
-		staking.decreaseAVAXAssigned(owner, avaxLiquidStakerAmt);
-		staking.decreaseAVAXValidating(owner, avaxLiquidStakerAmt);
+		staking.decreaseAVAXAssigned(mp.owner, mp.avaxLiquidStakerAmt);
+		staking.decreaseAVAXValidating(mp.owner, mp.avaxLiquidStakerAmt);
 
 		emit MinipoolStatusChanged(nodeID, MinipoolStatus.Withdrawable);
 	}
@@ -550,6 +536,7 @@ contract MinipoolManager is Base, ReentrancyGuard, IWithdrawer {
 		vault.depositAVAX{value: avaxNodeOpAmt}();
 
 		// Return Liq stakers funds
+		TokenggAVAX ggAVAX = TokenggAVAX(payable(getContractAddress("TokenggAVAX")));
 		ggAVAX.depositFromStaking{value: avaxLiquidStakerAmt}(avaxLiquidStakerAmt, 0);
 
 		Staking staking = Staking(getContractAddress("Staking"));

--- a/test/unit/AVAXHighWaterTest.t.sol
+++ b/test/unit/AVAXHighWaterTest.t.sol
@@ -139,8 +139,8 @@ contract AVAXStateVariableTest is BaseTest {
 
 		// create minipools
 		MinipoolManager.Minipool memory mp1 = createMinipool(depositAmt, assignmentRequest, duration);
-		MinipoolManager.Minipool memory mp2 = createMinipool(depositAmt, assignmentRequest, duration);
-		MinipoolManager.Minipool memory mp3 = createMinipool(depositAmt, assignmentRequest, duration);
+		createMinipool(depositAmt, assignmentRequest, duration);
+		createMinipool(depositAmt, assignmentRequest, duration);
 		vm.stopPrank();
 
 		// launch one minipool
@@ -197,8 +197,8 @@ contract AVAXStateVariableTest is BaseTest {
 
 		// create more minipools that are in queue (unlaunched)
 		vm.startPrank(nodeOp);
-		MinipoolManager.Minipool memory mp2 = createMinipool(depositAmt, assignmentRequest, duration);
-		MinipoolManager.Minipool memory mp3 = createMinipool(depositAmt, assignmentRequest, duration);
+		createMinipool(depositAmt, assignmentRequest, duration);
+		createMinipool(depositAmt, assignmentRequest, duration);
 		vm.stopPrank();
 
 		// make sure to distribute ggp before processing first rewards

--- a/test/unit/MinipoolManager.t.sol
+++ b/test/unit/MinipoolManager.t.sol
@@ -501,7 +501,6 @@ contract MinipoolManagerTest is BaseTest {
 		uint256 duration = 2 weeks;
 		uint256 depositAmt = 1000 ether;
 		uint256 avaxAssignmentRequest = 1000 ether;
-		uint256 validationAmt = depositAmt + avaxAssignmentRequest;
 		uint128 ggpStakeAmt = 200 ether;
 
 		vm.startPrank(nodeOp);

--- a/test/unit/utils/BaseTest.sol
+++ b/test/unit/utils/BaseTest.sol
@@ -100,16 +100,16 @@ abstract contract BaseTest is Test {
 		ggAVAX.initialize(store, wavax, 0 ether);
 		vm.startPrank(guardian);
 
-		minipoolMgr = new MinipoolManager(store, ggp, ggAVAX);
+		minipoolMgr = new MinipoolManager(store);
 		registerContract(store, "MinipoolManager", address(minipoolMgr));
 
 		multisigMgr = new MultisigManager(store);
 		registerContract(store, "MultisigManager", address(multisigMgr));
 
-		staking = new Staking(store, ggp);
+		staking = new Staking(store);
 		registerContract(store, "Staking", address(staking));
 
-		nopClaim = new ClaimNodeOp(store, ggp);
+		nopClaim = new ClaimNodeOp(store);
 		registerContract(store, "ClaimNodeOp", address(nopClaim));
 
 		daoClaim = new ClaimProtocolDAO(store);

--- a/test/unit/utils/MockERC20Upgradeable.sol
+++ b/test/unit/utils/MockERC20Upgradeable.sol
@@ -21,7 +21,7 @@ contract MockERC20Upgradeable is Initializable, ERC20Upgradeable {
 		_burn(from, value);
 	}
 
-	function versionHash() internal view override returns (bytes32) {
+	function versionHash() internal pure override returns (bytes32) {
 		return keccak256(abi.encodePacked(uint256(2)));
 	}
 }


### PR DESCRIPTION
C4 issue: https://github.com/code-423n4/2022-12-gogopool-findings/issues/739

We removed the ggp token from constructors in favor of retrieving it from storage.

The second commit was some test warning cleanup.